### PR TITLE
core: Revert "chore: Fix API index generation by ignoring "compute small""

### DIFF
--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -28,7 +28,7 @@ echo "-I$GOOGLEAPIS" >> tmp/protoc-options.txt
 echo "--include_imports" >> tmp/protoc-options.txt
 echo "--descriptor_set_out=tmp/all-protos.ds" >> tmp/protoc-options.txt
 echo "--experimental_allow_proto3_optional" >> tmp/protoc-options.txt
-find $GOOGLEAPIS/google -name '*.proto' | grep -v compute_small.proto >> tmp/protoc-options.txt
+find $GOOGLEAPIS/google -name '*.proto' >> tmp/protoc-options.txt
 find $GOOGLEAPIS/grafeas -name '*.proto' >> tmp/protoc-options.txt
 
 echo "Generating descriptor set."

--- a/src/Google.Cloud.Tools.ApiIndexGenerator/ApiModel.cs
+++ b/src/Google.Cloud.Tools.ApiIndexGenerator/ApiModel.cs
@@ -134,8 +134,6 @@ namespace Google.Cloud.Tools.ApiIndexGenerator
                 {
                     string relativeDirectory = Path.GetRelativePath(googleApisRoot, directory).Replace('\\', '/');
                     var configsInDirectory = System.IO.Directory.GetFiles(directory, "*.yaml")
-                        // Currently google/cloud/compute/v1 contains two service config files (and two protos for the same service)
-                        .Where(file => !file.EndsWith("compute_small_v1.yaml"))
                         .Select(ServiceConfig.TryLoadFile)
                         .Where(config => config != null)
                         .ToList();


### PR DESCRIPTION
This reverts commit eafc1447bab26545618e843db58ff4a74d7ccf31.

The extraneous "small" proto and corresponding files have been moved.