### PR TITLE
chore: Update the generator to .NET 6

### DIFF
--- a/.github/workflows/golden.yaml
+++ b/.github/workflows/golden.yaml
@@ -13,10 +13,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v2
 
-    - name: Setup .NET 5
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Test
       run: |

--- a/src/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj
+++ b/src/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Google.Cloud.Tools.ApiIndexGenerator/Google.Cloud.Tools.ApiIndexGenerator.csproj
+++ b/src/Google.Cloud.Tools.ApiIndexGenerator/Google.Cloud.Tools.ApiIndexGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET 5 will be out of support in May; .NET 6 is an LTS version,
supported until November 2024.