### PR TITLE
fix: Include Location and LongRunning APIs

### DIFF
--- a/src/Google.Cloud.Tools.ApiIndexGenerator/ApiModel.cs
+++ b/src/Google.Cloud.Tools.ApiIndexGenerator/ApiModel.cs
@@ -150,9 +150,13 @@ namespace Google.Cloud.Tools.ApiIndexGenerator
             void AddServiceConfigsRecursively(string directory)
             {
                 // Only load service config files from versioned directories (e.g. "google/spanner/v1")
-                if (ApiMajorVersionPattern.IsMatch(Path.GetFileName(directory)))
+                // The google/longrunning and google/cloud/location directories are exceptions to this
+                // which existed before the versioning schema was finalized.
+                string relativeDirectory = Path.GetRelativePath(googleApisRoot, directory).Replace('\\', '/');
+                if (ApiMajorVersionPattern.IsMatch(Path.GetFileName(directory)) ||
+                    relativeDirectory == "google/longrunning" ||
+                    relativeDirectory == "google/cloud/location")
                 {
-                    string relativeDirectory = Path.GetRelativePath(googleApisRoot, directory).Replace('\\', '/');
                     var configsInDirectory = System.IO.Directory.GetFiles(directory, "*.yaml")
                         .Select(ServiceConfig.TryLoadFile)
                         .Where(config => config != null)

--- a/test/golden-index-v1.json
+++ b/test/golden-index-v1.json
@@ -399,6 +399,113 @@
         "google.cloud.speech.v1p1beta1.Speech"
       ],
       "nameInServiceConfig": "speech.googleapis.com"
+    },
+    {
+      "id": "google.longrunning",
+      "directory": "google/longrunning",
+      "version": "longrunning",
+      "hostName": "longrunning.googleapis.com",
+      "title": "Long Running Operations API",
+      "description": "<UNKNOWN - NO SERVICE CONFIG DOCUMENTATION SUMMARY>",
+      "importDirectories": [
+        "google/api",
+        "google/protobuf",
+        "google/rpc"
+      ],
+      "options": {
+        "cc_enable_arenas": {
+          "valueCounts": {
+            "true": 1
+          }
+        },
+        "csharp_namespace": {
+          "valueCounts": {
+            "Google.LongRunning": 1
+          }
+        },
+        "go_package": {
+          "valueCounts": {
+            "google.golang.org/genproto/googleapis/longrunning;longrunning": 1
+          }
+        },
+        "java_multiple_files": {
+          "valueCounts": {
+            "true": 1
+          }
+        },
+        "java_package": {
+          "valueCounts": {
+            "com.google.longrunning": 1
+          }
+        },
+        "php_namespace": {
+          "valueCounts": {
+            "Google\\LongRunning": 1
+          }
+        }
+      },
+      "services": [
+        {
+          "shortName": "Operations",
+          "fullName": "google.longrunning.Operations",
+          "methods": [
+            {
+              "shortName": "CancelOperation",
+              "fullName": "google.longrunning.Operations.CancelOperation",
+              "mode": "UNARY",
+              "bindings": [
+                {
+                  "httpMethod": "POST",
+                  "path": "/v1/{name=operations/**}:cancel"
+                }
+              ]
+            },
+            {
+              "shortName": "DeleteOperation",
+              "fullName": "google.longrunning.Operations.DeleteOperation",
+              "mode": "UNARY",
+              "bindings": [
+                {
+                  "httpMethod": "DELETE",
+                  "path": "/v1/{name=operations/**}"
+                }
+              ]
+            },
+            {
+              "shortName": "GetOperation",
+              "fullName": "google.longrunning.Operations.GetOperation",
+              "mode": "UNARY",
+              "bindings": [
+                {
+                  "httpMethod": "GET",
+                  "path": "/v1/{name=operations/**}"
+                }
+              ]
+            },
+            {
+              "shortName": "ListOperations",
+              "fullName": "google.longrunning.Operations.ListOperations",
+              "mode": "UNARY",
+              "bindings": [
+                {
+                  "httpMethod": "GET",
+                  "path": "/v1/{name=operations}"
+                }
+              ]
+            },
+            {
+              "shortName": "WaitOperation",
+              "fullName": "google.longrunning.Operations.WaitOperation",
+              "mode": "UNARY"
+            }
+          ]
+        }
+      ],
+      "configFile": "longrunning.yaml",
+      "serviceConfigApiNames": [
+        "google.longrunning.Operations"
+      ],
+      "nameInServiceConfig": "longrunning.googleapis.com"
     }
   ],
   "metadata": {


### PR DESCRIPTION
These were previously excluded due to being in unversioned directories.