### PR TITLE
chore: Upgrade to .NET 8

### DIFF
--- a/.github/workflows/golden.yaml
+++ b/.github/workflows/golden.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET 6
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Test
       run: |

--- a/src/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj
+++ b/src/Google.Cloud.Tools.ApiIndex.V1/Google.Cloud.Tools.ApiIndex.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Google.Cloud.Tools.ApiIndexGenerator/Google.Cloud.Tools.ApiIndexGenerator.csproj
+++ b/src/Google.Cloud.Tools.ApiIndexGenerator/Google.Cloud.Tools.ApiIndexGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET 6 is no longer supported.

Fixed #131