### PR TITLE
fix: Use a consistent ordering when finding service config files

### DIFF
--- a/src/Google.Cloud.Tools.ApiIndexGenerator/ApiModel.cs
+++ b/src/Google.Cloud.Tools.ApiIndexGenerator/ApiModel.cs
@@ -158,6 +158,7 @@ namespace Google.Cloud.Tools.ApiIndexGenerator
                     relativeDirectory == "google/cloud/location")
                 {
                     var configsInDirectory = System.IO.Directory.GetFiles(directory, "*.yaml")
+                        .Order(StringComparer.Ordinal)
                         .Select(ServiceConfig.TryLoadFile)
                         .Where(config => config != null)
                         .ToList();


### PR DESCRIPTION
This will only affect anything when there's more than one service config file for an API (which is a bad situation in general) but it at least means we'll be consistent about which file we pick.

(This only affects Spanner Admin Instance at the moment.)