### PR TITLE
chore: replace old dotnet teams with cloud-sdk-dotnet-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 
 # The yoshi-dotnet team is the default owner for anything not
 # explicitly taken by someone else.
-*                                   @googleapis/yoshi-dotnet
+*                                   @googleapis/cloud-sdk-dotnet-team


### PR DESCRIPTION
b/479544839